### PR TITLE
Minor change to readme, and update to references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 ﻿# relativity-integration-test-helpers
-Open Source Community: Integration testing is a software testing methodology used to test individual software components or units of code to verify their interaction. These components are tested as a single group or organized in an iterative manner.That said, we have created Relativity Integration Test Helpers to assist you with writing good Integration Tests for your Relativity application. You can use this framework to test event handlers, agents or any workflow that combines agents and Eventhandlers. We will continue adding more helpers but in the mean time you should be able to create workspaces, create dbcontext, proxy and create documents with this framework.
+Open Source Community: Integration testing is a software testing methodology used to test individual software components or units of code to verify their interaction. These components are tested as a single group or organized in an iterative manner. That said, we have created Relativity Integration Test Helpers to assist you with writing good Integration Tests for your Relativity application. You can use this framework to test event handlers, agents or any workflow that combines agents and Eventhandlers. We will continue adding more helpers but in the mean time you should be able to create workspaces, create dbcontext, proxy and create documents with this framework.
  This framework is only compatible for Relativity 9.5 and above.
  
-This project requires references to kCura's Relativity® SDK dlls. These dlls are not part of the open source project and can be obtained by contacting support@kCura.com or getting it from your Relativity instance. 
+This project requires references to kCura's Relativity® SDK dlls. These dlls are not part of the open source project and can be obtained by contacting support@kCura.com, getting it from your Relativity instance, or installing the SDK from the [Community Portal](https://community.relativity.com/s/files).
 Under "relativity-integration-test-helpers\Source\Relativity.Test.Helpers\" you will need to create a "Packages" folder if one does not exist and you will need to add the following dlls to this folder. Once you do that you should be able to run your integration tests against an environment.
-
 
 • FreeImageNET.dll
 • kCura.Relativity.Client.dll

--- a/Source/Relativity.Test.Helpers/Relativity.Test.Helpers/Relativity.Test.Helpers.csproj
+++ b/Source/Relativity.Test.Helpers/Relativity.Test.Helpers/Relativity.Test.Helpers.csproj
@@ -53,93 +53,37 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FreeImageNET">
-      <HintPath>..\Packages\FreeImageNET.dll</HintPath>
-    </Reference>
-    <Reference Include="Ionic.Zip">
-      <HintPath>..\Packages\Ionic.Zip.dll</HintPath>
-    </Reference>
-    <Reference Include="itextsharp">
-      <HintPath>..\Packages\itextsharp.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Config">
-      <HintPath>..\Packages\kCura.Config.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Data">
-      <HintPath>..\Packages\kCura.Data.dll</HintPath>
-    </Reference>
     <Reference Include="kCura.Data.RowDataGateway">
-      <HintPath>..\Packages\kCura.Data.RowDataGateway.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.ImageValidator">
-      <HintPath>..\Packages\kCura.ImageValidator.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Injection">
-      <HintPath>..\Packages\kCura.Injection.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.OI.FileID">
-      <HintPath>..\Packages\kCura.OI.FileID.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\Agents\Client\kCura.Data.RowDataGateway.dll</HintPath>
     </Reference>
     <Reference Include="kCura.Relativity.Client">
-      <HintPath>..\Packages\kCura.Relativity.Client.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\Services API\Client\kCura.Relativity.Client.dll</HintPath>
     </Reference>
     <Reference Include="kCura.Relativity.DataReaderClient">
-      <HintPath>..\Packages\kCura.Relativity.DataReaderClient.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\ImportAPI\Client\x64\kCura.Relativity.DataReaderClient.dll</HintPath>
     </Reference>
     <Reference Include="kCura.Relativity.ImportAPI">
-      <HintPath>..\Packages\kCura.Relativity.ImportAPI.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Utility">
-      <HintPath>..\Packages\kCura.Utility.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Windows.Forms">
-      <HintPath>..\Packages\kCura.Windows.Forms.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Windows.Process">
-      <HintPath>..\Packages\kCura.Windows.Process.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.WinEDDS">
-      <HintPath>..\Packages\kCura.WinEDDS.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.WinEDDS.ImportExtension">
-      <HintPath>..\Packages\kCura.WinEDDS.ImportExtension.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\Packages\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\ImportAPI\Client\x64\kCura.Relativity.ImportAPI.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PresentationFramework.AeroLite" />
-    <Reference Include="Relativity">
-      <HintPath>..\Packages\Relativity.dll</HintPath>
-    </Reference>
     <Reference Include="Relativity.API">
-      <HintPath>..\Packages\Relativity.API.dll</HintPath>
-    </Reference>
-    <Reference Include="Relativity.Services">
-      <HintPath>..\Packages\Relativity.Services.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\Relativity API\Lib\Relativity.API.dll</HintPath>
     </Reference>
     <Reference Include="Relativity.Services.DataContracts">
-      <HintPath>..\Packages\Relativity.Services.DataContracts.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\Services API\Client\Relativity.Services.DataContracts.dll</HintPath>
     </Reference>
     <Reference Include="Relativity.Services.Interfaces">
-      <HintPath>..\Packages\Relativity.Services.Interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Relativity.Services.Interfaces.Private">
-      <HintPath>..\Packages\Relativity.Services.Interfaces.Private.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\Services API\Client\Relativity.Services.Interfaces.dll</HintPath>
     </Reference>
     <Reference Include="Relativity.Services.ServiceProxy">
-      <HintPath>..\Packages\Relativity.Services.ServiceProxy.dll</HintPath>
-    </Reference>
-    <Reference Include="Relativity.Toggles">
-      <HintPath>..\Packages\Relativity.Toggles.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\kCura Corporation\Relativity SDK\Services API\Client\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.XML" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Source/Relativity.Test.Helpers/Relativity.Test.Helpers/TestTemplate.cs
+++ b/Source/Relativity.Test.Helpers/Relativity.Test.Helpers/TestTemplate.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.util;
 using kCura.Relativity.Client;
 using NUnit.Framework;
 using Relativity.API;


### PR DESCRIPTION
The readme was lacking a link to the community portal (which is where the SDK is stored).  Also, the references were really crazy, with a lot of assemblies that aren't used or weren't pointing to the standard SDK location.